### PR TITLE
message.iniをシングルトンにする

### DIFF
--- a/data_gorvernance/library/utils/config/__init__.py
+++ b/data_gorvernance/library/utils/config/__init__.py
@@ -5,3 +5,4 @@
 """
 from . import message
 from . import path_config
+from . import config_parser_base

--- a/data_gorvernance/library/utils/config/__init__.py
+++ b/data_gorvernance/library/utils/config/__init__.py
@@ -5,4 +5,3 @@
 """
 from . import message
 from . import path_config
-from . import config_parser_base

--- a/data_gorvernance/library/utils/config/config_parser_base.py
+++ b/data_gorvernance/library/utils/config/config_parser_base.py
@@ -1,7 +1,6 @@
 """ 設定ファイルから情報を読み取るためのモジュールです。
 
-設定ファイルをシングルトンに読み込む基底クラスが記載されています。
-
+設定ファイルを読み込むための基底クラスが記載されています。
 """
 from __future__ import annotations
 import configparser
@@ -14,7 +13,6 @@ class ConfigParserBase:
             _instance (ConfigParserBase): シングルトンインスタンスを格納する
         instance:
             _config_file (ConfigParser): 設定ファイルの情報を保持するインスタンス
-
     """
     _instance = None
 
@@ -23,14 +21,13 @@ class ConfigParserBase:
 
         Returns:
             ConfigParserBase: このクラスのシングルトンインスタンスを返す。
-
         """
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance.initialize(*args, **kwargs)
         return cls._instance
 
-    def initialize(self, config_path: str, encoding: str='utf-8'):
+    def initialize(self, config_path: str, encoding: str = 'utf-8'):
         """  設定ファイルを読み込むメソッドです。
 
         Args:
@@ -48,6 +45,5 @@ class ConfigParserBase:
             option (str): 設定ファイルの項目名を設定します。
         Returns:
             str: 対応する設定値を返す。
-
         """
         return self._config_file[section][option]

--- a/data_gorvernance/library/utils/config/config_parser_base.py
+++ b/data_gorvernance/library/utils/config/config_parser_base.py
@@ -1,0 +1,53 @@
+""" 設定ファイルから情報を読み取るためのモジュールです。
+
+設定ファイルをシングルトンに読み込む基底クラスが記載されています。
+
+"""
+from __future__ import annotations
+import configparser
+
+class ConfigParserBase:
+    """ 設定ファイルを保持するシングルトンクラスです。
+
+    Args:
+        class:
+            _instance (ConfigParserBase): シングルトンインスタンスを格納する
+        instance:
+            _config_file (ConfigParser): 設定ファイルの情報を保持するインスタンス
+
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs) -> ConfigParserBase:
+        """ 新しいインスタンス作成時に既存のインスタンスを返すメソッドです。
+
+        Returns:
+            ConfigParserBase: このクラスのシングルトンインスタンスを返す。
+
+        """
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.initialize(*args, **kwargs)
+        return cls._instance
+
+    def initialize(self, config_path: str, encoding: str='utf-8'):
+        """  設定ファイルを読み込むメソッドです。
+
+        Args:
+            config_path (str): 設定ファイルのパス
+            encoding (str): 設定ファイルのエンコーディング
+        """
+        self._config_file = configparser.ConfigParser()
+        self._config_file.read(config_path, encoding=encoding)
+
+    def get(self, section: str, option: str) -> str:
+        """ 指名されたセクションの項目名に対応する値を取得するメソッドです。
+
+        Args:
+            section (str): 設定ファイルのセクションを設定します。
+            option (str): 設定ファイルの項目名を設定します。
+        Returns:
+            str: 対応する設定値を返す。
+
+        """
+        return self._config_file[section][option]

--- a/data_gorvernance/library/utils/config/message.py
+++ b/data_gorvernance/library/utils/config/message.py
@@ -1,7 +1,7 @@
 """ 設定ファイルからメッセージを取得するためのモジュールです。"""
 import os
 
-from library.utils.config.config_parser_base import ConfigParserBase
+from .config_parser_base import ConfigParserBase
 
 MESSAGE_CONFIG_PATH = '../../data/message.ini'
 script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/data_gorvernance/library/utils/config/message.py
+++ b/data_gorvernance/library/utils/config/message.py
@@ -1,56 +1,11 @@
 """ 設定ファイルからメッセージを取得するためのモジュールです。"""
-import configparser
 import os
+
+from library.utils.config.config_parser_base import ConfigParserBase
 
 MESSAGE_CONFIG_PATH = '../../data/message.ini'
 script_dir = os.path.dirname(os.path.abspath(__file__))
 message_ini_path = os.path.abspath(os.path.join(script_dir, MESSAGE_CONFIG_PATH))
-
-class ConfigParserBase:
-    """ 設定ファイルを保持するシングルトンクラスです。
-
-    Args:
-        class:
-            _instance (ConfigParserBase): シングルトンインスタンスを格納する
-
-    """
-    _instance = None
-
-    def __new__(cls, *args, **kwargs) -> "ConfigParserBase":
-        """ 新しいインスタンス作成時に既存のインスタンスを返すメソッドです。
-
-        Returns:
-            ConfigParserBase: このクラスのシングルトンインスタンスを返す。
-
-        """
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._instance.initialize(*args, **kwargs)
-        return cls._instance
-
-    def initialize(self, config_path: str, encoding: str = 'utf-8'):
-        """  設定ファイルを読み込むメソッドです。
-
-        Args:
-            config_path (str): 設定ファイルのパス
-            encoding (str): 設定ファイルのエンコーディング
-        """
-        self._config_path = config_path
-        self._config_file = configparser.ConfigParser()
-        self._config_file.read(config_path, encoding=encoding)
-
-    def get(self, section: str, option: str) -> str:
-        """ 指名されたセクションの項目名に対応する値を取得するメソッドです。
-
-        Args:
-            section (str): 設定ファイルのセクションを設定します。
-            option (str): 設定ファイルの項目名を設定します。
-        Returns:
-            str: 対応する設定値を返す。
-
-        """
-        return self._config_file.get(section,option)
-
 
 class Message(ConfigParserBase):
     """ message.iniを読み込むためのクラスです。"""

--- a/data_gorvernance/library/utils/config/message.py
+++ b/data_gorvernance/library/utils/config/message.py
@@ -19,7 +19,6 @@ def get(section: str, option: str) -> str:
         option (str): message.iniのキーを設定します。
     Returns:
         str: メッセージを返す。
-
     """
     config = Message(message_ini_path)
     return config.get(section, option)

--- a/data_gorvernance/library/utils/config/message.py
+++ b/data_gorvernance/library/utils/config/message.py
@@ -11,7 +11,7 @@ class ConfigParserBase:
 
     Args:
         class:
-            _instance (Message): シングルトンインスタンスを格納する
+            _instance (ConfigParserBase): シングルトンインスタンスを格納する
 
     """
     _instance = None
@@ -46,7 +46,7 @@ class ConfigParserBase:
             section (str): 設定ファイルのセクションを設定します。
             option (str): 設定ファイルの項目名を設定します。
         Returns:
-            str: 設定値を返す。
+            str: 対応する設定値を返す。
 
         """
         return self._config_file.get(section,option)

--- a/data_gorvernance/library/utils/config/message.py
+++ b/data_gorvernance/library/utils/config/message.py
@@ -6,6 +6,35 @@ MESSAGE_CONFIG_PATH = '../../data/message.ini'
 script_dir = os.path.dirname(os.path.abspath(__file__))
 message_ini_path = os.path.abspath(os.path.join(script_dir, MESSAGE_CONFIG_PATH))
 
+class Message(configparser.ConfigParser):
+    """ メッセージファイルを保持するためのシングルトンなクラスです。
+
+    Args:
+        class:
+            _instance (Message): シングルトンインスタンスを格納する
+
+    """
+
+    def __new__(cls, *args, **kwargs)->'Message':
+        """ 新しいインスタンス作成時に既存のインスタンスを返すメソッドです。
+
+        Returns:
+            Message: シングルトンインスタンスを返す。
+
+        """
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls, *args, **kwargs)
+        return cls._instance
+
+    def __init__(self, *args, **kwargs):
+        """ インスタンスの初期化処理を実行するメソッドです。
+
+        インスタンス初期化時に設定ファイルを読み込みます。
+
+        """
+        super().__init__(*args, **kwargs)
+        self.read(message_ini_path, encoding='utf-8')
+
 
 def get(section:str, option:str) -> str:
     """ メッセージを取得する関数です。
@@ -17,7 +46,5 @@ def get(section:str, option:str) -> str:
         str: メッセージを返す。
 
     """
-    config = configparser.ConfigParser()
-    config.read(message_ini_path, encoding='utf-8')
-
+    config = Message()
     return config[section][option]


### PR DESCRIPTION
# PULL REQUEST

## Background

* 現在、message.iniからメッセージを取得する関数では、呼び出されるたびにインスタンスを生成している。


## Main Points of Modification

* シングルトンに修正し、インスタンスは各セルで一回だけ作成されるようにする。

## Test

* 一時的にprint文を追加してオブジェクトのメモリアドレスを確認。
  * 修正前
![image](https://github.com/user-attachments/assets/6976fb82-13e8-4a90-b8f6-8d5baef068a5)
  * 修正後
![image](https://github.com/user-attachments/assets/266cbd60-423d-46d5-b78d-82daba284278)

## Viewpoint for Review

*

## Supplementary Information

*

## ToDo

*