### PR TITLE
rdmclientのバージョンを固定する

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --no-cache pandas==2.1.4
 RUN pip install --no-cache cookiecutter==2.5.0
 RUN pip install --no-cache hvac==2.1.0
 RUN pip install --no-cache gitpython==3.1.43
-RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@974fb396f43e6ad7f9e5f96bf6d1624fb6a08915
+RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@ab531e89148c4af48e4e1f123edc8e35690f31bc
 RUN pip install --no-cache git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
 RUN pip install --no-cache git+https://github.com/NII-DG/dg-packager.git@master
 

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --no-cache pandas==2.1.4
 RUN pip install --no-cache cookiecutter==2.5.0
 RUN pip install --no-cache hvac==2.1.0
 RUN pip install --no-cache gitpython==3.1.43
-RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@master
+RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@5bbd9e99125e0d3fba2f23e8a92266b01de3b1f1
 RUN pip install --no-cache git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
 RUN pip install --no-cache git+https://github.com/NII-DG/dg-packager.git@master
 

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --no-cache pandas==2.1.4
 RUN pip install --no-cache cookiecutter==2.5.0
 RUN pip install --no-cache hvac==2.1.0
 RUN pip install --no-cache gitpython==3.1.43
-RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@5bbd9e99125e0d3fba2f23e8a92266b01de3b1f1
+RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@ab531e89148c4af48e4e1f123edc8e35690f31bc
 RUN pip install --no-cache git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
 RUN pip install --no-cache git+https://github.com/NII-DG/dg-packager.git@master
 

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --no-cache pandas==2.1.4
 RUN pip install --no-cache cookiecutter==2.5.0
 RUN pip install --no-cache hvac==2.1.0
 RUN pip install --no-cache gitpython==3.1.43
-RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@ab531e89148c4af48e4e1f123edc8e35690f31bc
+RUN pip install --no-cache git+https://github.com/RCOSDP/rdmclient.git@974fb396f43e6ad7f9e5f96bf6d1624fb6a08915
 RUN pip install --no-cache git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
 RUN pip install --no-cache git+https://github.com/NII-DG/dg-packager.git@master
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* rdmclientをブランチ指定で取り込んでおり、変更がコード付帯のキャッシュに依存している
* rdmclientに大幅な変更が入った

## Main Points of Modification

* rdmclientのコミット（2024/9/3のもの）を指定してインストールするようにした

## Test

* コード付帯上で同期が動くことを確認
新規追加したファイルの同期を確認
![image](https://github.com/user-attachments/assets/e9557091-dca0-4cca-9466-f830632e8829)
![image](https://github.com/user-attachments/assets/7fe67b04-53a4-4d73-8d94-8df9bfe7148a)

同期の正常終了を確認
![image](https://github.com/user-attachments/assets/401cd2b5-75eb-4c5c-acb2-0e364ea5114c)

## Viewpoint for Review

* None

## Supplementary Information

* None

## ToDo

* None