### PR TITLE
Update unit_test.yml

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       # リポジトリをチェックアウト


### PR DESCRIPTION
remove Python 3.8 from the test target versions

# PULL REQUEST

## Background

* Considering the end of life of Python 3.8, we decided to unsupport the version.

## Main Points of Modification

* Python 3.8 was removed from the test target versions.

## Test

* None

## Viewpoint for Review

* Successful run of the GitHub Action

## Supplementary Information

* None

## ToDo

* None