### PR TITLE
fix: pin param to 2.2.1 to avoid Constant 'name' breaking change

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -55,6 +55,7 @@ RUN pip install --no-cache chardet==4.0.0
 RUN pip install --no-cache openpyxl==3.1.3
 RUN pip install --no-cache owlrl==7.1.2
 RUN pip install --no-cache pandas==2.1.4
+RUN pip install --no-cache param==2.2.1
 RUN pip install --no-cache panel==1.3.0
 RUN pip install --no-cache pikepdf==9.5.1
 RUN pip install --no-cache python-magic==0.4.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ osfclient @ git+https://github.com/RCOSDP/rdmclient.git@d9d2b7926ecdf53aede026e6
 owlrl==7.1.4
 pandas==2.1.4
 panel==1.3.0
+param==2.2.1
 pikepdf==9.5.1
 python_dateutil==2.9.0.post0
 rdflib==7.2.1


### PR DESCRIPTION
# PULL REQUEST

## Background

* フォームの作成に使用しているPanelパッケージが依存するparamパッケージのアップデートの影響でセル実行時にエラーになってしまった

## Main Points of Modification

* paramのパッケージのバージョンを2.2.1で固定した（現在の最新は2.3.1）

## Test

* ローカルでエラーになったので、ローカルでPanelの表示がエラーにならないことを確認した

## Viewpoint for Review

*

## Supplementary Information

*

## ToDo

*